### PR TITLE
clean up..

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .gradle
 .classpath
 .project
+.settings
 build/
 .README.md
 .README.md.html

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,6 @@
 apply plugin: 'java'
 apply plugin: 'eclipse'
 apply plugin: 'application'
-apply plugin: 'jetty'
 
 // compiler options
 sourceCompatibility = JavaVersion.VERSION_1_8
@@ -28,18 +27,6 @@ dependencies {
 /* ******************* */
 mainClassName = 'app.SimpleMain'
 
-
-/* ******************* */
-/*   Jetty webserver   */
-/* ******************* */
-jettyRun {
-	contextPath = ''
-	reload = 'manual' // 'manual' reloads the entire webapp when pressing 'enter'
-	scanIntervalSeconds = 100 // only used with reload = 'automatic'
-	
-	System.setProperty("JAWN_ENV","development")
-	System.setProperty("jawn_reload","true")
-}
 
 /* ****************** */
 /*    Eclipse         */


### PR DESCRIPTION
The jetty plugin is not available for never versions of gradle, which makes it impossible to use the build file with current version.
Since undertow is default web server anyway, the jetty config has been removed.